### PR TITLE
Finds latest version of speedtest-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 To use this widget you will need to install the speedtest package
 
 ```
-pkg update ; pkg install -y py37-speedtest-cli
+pkg update ; pkg install -y $( pkg search speedtest-cli | awk '{ print $1 }' )
 ```
 
 Copy the widget file **speedtest.widget.php** to **/usr/local/www/widgets/widgets/** on your pfSense machine.


### PR DESCRIPTION
Use awk to simply pull the latest speedtest-cli package rather than hard coding the version number.